### PR TITLE
Fixed bug in zModifySettings() and zSetSurfaceData()

### DIFF
--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -3130,7 +3130,10 @@ class PyZDDE(object):
                  -2 = incorrect version number
                  -3 = file access conflict
         """
-        cmd = "ModifySettings,{},{},{:1.20g}".format(fileName,mType,value)
+        if isinstance(value, str):
+            cmd = "ModifySettings,{},{},{}".format(fileName,mType,value)
+        else:
+            cmd = "ModifySettings,{},{},{:1.20g}".format(fileName,mType,value)
         reply = self.conversation.Request(cmd)
         return int(float(reply.rstrip()))
 
@@ -5066,7 +5069,11 @@ class PyZDDE(object):
                 raise ValueError('Invalid input, expecting argument')
         reply = self.conversation.Request(cmd)
         if code in (0,1,4,7,9):
-            surfaceDatum = reply.split()[0]
+            surfaceDatum = reply.split()
+            if len(surfaceDatum):
+                surfaceDatum = surfaceDatum[0]
+            else:
+                surfaceDatum = ''
         else:
             surfaceDatum = float(reply)
         return surfaceDatum


### PR DESCRIPTION
Hi,
I'm increasingly using your great library and really love it.

During the last few days I came across problems in the functions `zModifySettings()` and `zSetSurfaceData()`:
- When modifying settings that expect a string as value to be set `zModifySettings()` raised an error because the value is formatted into the transaction string expecting a number. For example when setting the operand name in a set of settings for an Universal Plot 1D this error would occur. I added a type check that treats numbers and strings accordingly.
- When setting a glass to air an empty value string is sent to ZEMAX by `zSetSurfaceData()` as part of the transaction. ZEMAX returns the glass name that has been set to indicate success. In this case `zSetSurfaceData()` raised an error because the `split()` of the response string returned an empty list. Accessing the first (nonexistent) item in this list produced the error. I added a check for whether the list contains anything and return the first item in this case and an empty string if otherwise.

So far the fixes seem to work - feel free to modify them.

Best regards
Uwe
