### PR TITLE
Update zdde.py

### DIFF
--- a/pyzdde/zdde.py
+++ b/pyzdde/zdde.py
@@ -4332,7 +4332,7 @@ class PyZDDE(object):
         if update == 1:
             reply = self._sendDDEcommand('PushLens,1', timeout)
         elif update == 0 or update is None:
-            reply = self._sendDDEcommand('PushLens', timeout)
+            reply = self._sendDDEcommand('PushLens,0', timeout)
         else:
             raise ValueError('Invalid value for flag')
         if reply:


### PR DESCRIPTION
Although stated otherwise in the ZEMAX manual, omitting the flag value of the PushLens() command will not prevent ZEMAX from updating all sub-windows. 
Explicitly added flag value 0 to the PushLens command to fix this issue.