### PR TITLE
Installation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,11 @@ local.properties
 .spyderworkspace
 .spyderproject
 
+#################
+## PyCharm
+#################
+.idea/
+
 ###############################
 ## Visual Studio/ PTVS projects
 ###############################

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+#-------------------------------------------------------------------------------
+# Name:        setup.py
+# Purpose:     Standard module installation script
+# Licence:     MIT License
+#              This file is subject to the terms and conditions of the MIT License.
+#              For further details, please refer to LICENSE.txt
+# Revision:    0.1
+#-------------------------------------------------------------------------------
+"""
+This script will install the PyZDDE library into your Lib/site-packages directory
+as a standard Python module. It can then be imported like any other module package.
+
+To use:
+- Open the command prompt (cmd.exe)
+- CD to the directory where this file is located
+- issue the command
+   python setup.py install
+"""
+
+from setuptools import setup, find_packages
+
+setup(
+    name="PyZDDE",
+    version="1.1.00",
+    description='Zemax / OpticStudio standalone extension using Python',
+    author='Indranil Sinharoy',
+    author_email='indranil_leo@yahoo.com',
+    license='MIT',
+    keywords='zemax opticstudio extensions dde',
+    url='https://github.com/indranilsinharoy/PyZDDE',
+    packages=find_packages()
+)


### PR DESCRIPTION
Created a setup.py file for installing PyZDDE into site-packages as a standard Python module.

I have ONLY tested this on Windows 7 / Anaconda 2.2.0 / Python 2.7.9, but as this little thing is just about as standard as it gets, I don't expect much trouble in other systems.

Even though writing these dozen or so lines of code was obviously an enormous amount of work, it does avoid the programmer having to jump through various hoops and loops to get the import working. Especially in those cases where one has to manage multiple platforms and computers & help those less nerdy Zemax users who aren't necessarily interested in learning about managing their environment variables.

Submitting PyZDDE to PyPI would require a few more actions (https://python-packaging-user-guide.readthedocs.org/en/latest/distributing.html) but this is a start and will likely already lower the entry barrier to others. At least I had to do quite a bit of hacking to ensure PyZDDE could be smoothly imported in all circumstances.

---

I also included the PyCharm IDE settings directory .idea/ into .gitignore. Merging this is of course entirely optional, just a personal convenience for me. Anyway, PyCharm is one of the more popular IDEs for Python.
